### PR TITLE
refactor: print errors instead of panicking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod utils;
 
 const MAX_LINK_NESTED_DEPTH: usize = 10;
 
+#[derive(Default)]
 pub struct Template;
 
 impl Template {
@@ -38,13 +39,8 @@ impl Preprocessor for Template {
                         .map(|dir| src_dir.join(dir))
                         .expect("All book items have a parent");
 
-                    let content = replace_template(
-                        &chapter.content,
-                        &SystemFileReader::default(),
-                        base,
-                        source,
-                        0,
-                    );
+                    let content =
+                        replace_template(&chapter.content, &SystemFileReader, base, source, 0);
                     chapter.content = content;
                 }
             }
@@ -79,7 +75,7 @@ where
     for link in links::extract_template_links(chapter_content) {
         replaced.push_str(&chapter_content[previous_end_index..link.start_index]);
 
-        match link.replace_args(&path, file_reader) {
+        match link.replace_args(path, file_reader) {
             Ok(new_content) => {
                 if depth < MAX_LINK_NESTED_DEPTH {
                     if let Some(rel_path) = link.link_type.relative_path(path) {
@@ -202,8 +198,8 @@ mod lib_tests {
         let start_chapter_content = r"
         {{#template header.md title=Example Title}}
         Some content...
-        {{#template 
-            footer.md 
+        {{#template
+            footer.md
         authors=Goudham & Hazel}}";
         let end_chapter_content = r"
         # Example Title

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,4 +292,24 @@ mod lib_tests {
 
         assert_eq!(actual_chapter_content, start_chapter_content);
     }
+
+    #[test]
+    fn test_sad_path_bad_template() {
+        let start_chapter_content = [
+            "This is {{#template template.md",
+            "text=valid text",
+            "this has no key for the value and is going to break things}}",
+        ]
+        .join("\n");
+        let end_chapter_content = "This is valid text";
+        let file_name: PathBuf = PathBuf::from("template.md");
+        let template_file_contents = "[[#text]]".to_string();
+        let map = HashMap::from([(file_name, template_file_contents)]);
+        let file_reader = &TestFileReader::from(map);
+
+        let actual_chapter_content =
+            replace_template(&start_chapter_content, file_reader, "", "", 0);
+
+        assert_eq!(actual_chapter_content, end_chapter_content);
+    }
 }

--- a/src/links.rs
+++ b/src/links.rs
@@ -515,9 +515,9 @@ year=2022
 
     #[test]
     fn test_extract_template_links_with_newlines_malformed() {
-        let s = "{{#template test.rs
+        let s = r#"{{#template test.rs 
         lang=rust
-        year=2022}}";
+        year=2022}}"#;
 
         let res = extract_template_links(s).collect::<Vec<_>>();
 
@@ -525,9 +525,9 @@ year=2022
             res,
             vec![Link {
                 start_index: 0,
-                end_index: 57,
+                end_index: 58,
                 link_type: LinkType::Template(PathBuf::from("test.rs")),
-                link_text: "{{#template test.rs\n        lang=rust\n        year=2022}}",
+                link_text: "{{#template test.rs \n        lang=rust\n        year=2022}}",
                 args: HashMap::from([("lang", "rust"), ("year", "2022")]),
             },]
         );

--- a/src/links.rs
+++ b/src/links.rs
@@ -122,7 +122,7 @@ impl<'a> Link<'a> {
                                 }
                             }
                             eprintln!(
-                                "Couldn't find key or value while parsing the argument '{}'",
+                                "Couldn't find a key/value pair while parsing the argument '{}'",
                                 mat
                             );
                             None
@@ -515,11 +515,14 @@ year=2022
 
     #[test]
     fn test_extract_template_links_with_newlines_malformed() {
-        let s = r#"{{#template test.rs 
-        lang=rust
-        year=2022}}"#;
+        let s = [
+            "{{#template test.rs \n",
+            "        lang=rust\n",
+            "        year=2022}}",
+        ]
+        .concat();
 
-        let res = extract_template_links(s).collect::<Vec<_>>();
+        let res = extract_template_links(&s).collect::<Vec<_>>();
 
         assert_eq!(
             res,

--- a/src/links.rs
+++ b/src/links.rs
@@ -121,7 +121,10 @@ impl<'a> Link<'a> {
                                     return Some((key, value));
                                 }
                             }
-                            eprintln!("Couldn't find key or value while parsing argument {}", mat);
+                            eprintln!(
+                                "Couldn't find key or value while parsing the argument '{}'",
+                                mat
+                            );
                             None
                         })
                         .collect::<Vec<_>>(),
@@ -139,7 +142,7 @@ impl<'a> Link<'a> {
                                 }
                             }
                             eprintln!(
-                                "Couldn't parse key or value while parsing {:?}",
+                                "Couldn't parse key or value while parsing '{:?}'",
                                 &args.as_str()
                             );
                             None


### PR DESCRIPTION
Previously when handling incorrectly formatted templates, `mdbook-template` would panic due to using `.unwrap()` while parsing the k/v pairs.

Also applied some clippy lints around borrows/iter usage.